### PR TITLE
add Tabs, TabHeading and TabContent components

### DIFF
--- a/src/TabContent/index.js
+++ b/src/TabContent/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const TabContent = ({ index, children }) => (
+  <div className="content" id={`content${index}`}>
+    {children}
+  </div>
+)
+
+export default TabContent

--- a/src/TabHeading/index.js
+++ b/src/TabHeading/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const TabHeading = ({ index, children, checked }) => {
+  return (
+    <>
+      <input
+        id={`tab${index}`}
+        type="radio"
+        name="tabs"
+        defaultChecked={checked}
+      />
+      <label htmlFor={`tab${index}`}>{children}</label>
+    </>
+  )
+}
+
+export default TabHeading

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+
+const Tabs = ({ children }) => {
+  const childrenElements = React.Children.toArray(children)
+
+  // Rearrange tab elements from ordering from:
+
+  // TabHeading 1
+  // TabContent 1
+  // TabHeading 2
+  // TabHeading 2
+
+  // to:
+
+  // TabHeading 1
+  // TabHeading 2
+  // TabContent 1
+  // TabContent 2
+
+  // PaperCSS requires the HTML tags to be ordered
+  // the second way. However I think the first way
+  // makes more sense therefoere the elements are rearranged.
+
+  const tabHeadings = childrenElements.filter((_, i) => i % 2 === 0)
+
+  const tabContents = childrenElements.filter((_, i) => i % 2 === 1)
+
+  const arrangedTabElements = [...tabHeadings, ...tabContents]
+
+  return <div className="row flex-spaces tabs">{arrangedTabElements}</div>
+}
+
+export default Tabs

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,4 @@
 export Image from './Image'
+export Tabs from './Tabs'
+export TabHeading from './TabHeading'
+export TabContent from './TabContent'

--- a/stories/Tabs.stories.js
+++ b/stories/Tabs.stories.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Tabs from '../src/Tabs'
+import TabHeading from '../src/TabHeading'
+import TabContent from '../src/TabContent'
+
+storiesOf('Tabs', module).add('two tabs', () => (
+  <Tabs>
+    <TabHeading index={1} checked={true}>
+      Tab 1
+    </TabHeading>
+    <TabContent index={1}>
+      <h4>Tab 1 Contents</h4>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Vestibulum lectus
+        mauris ultrices eros. Non diam phasellus vestibulum lorem sed risus
+        ultricies tristique. Odio ut enim blandit volutpat maecenas volutpat.
+        Egestas quis ipsum suspendisse ultrices gravida dictum. Elementum nibh
+        tellus molestie nunc non blandit. Tempor id eu nisl nunc mi ipsum. Dis
+        parturient montes nascetur ridiculus mus. Eu facilisis sed odio morbi
+        quis commodo odio. Facilisis mauris sit amet massa vitae. Elit sed
+        vulputate mi sit amet mauris.
+      </p>
+    </TabContent>
+    <TabHeading index={2}>Tab 2</TabHeading>
+    <TabContent index={2}>
+      <h4>Tab 2 Contents</h4>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Lorem donec massa
+        sapien faucibus et molestie. Pretium lectus quam id leo in vitae turpis
+        massa. Dis parturient montes nascetur ridiculus mus mauris vitae. Tellus
+        pellentesque eu tincidunt tortor aliquam nulla facilisi cras.
+        Sollicitudin aliquam ultrices sagittis orci. Varius vel pharetra vel
+        turpis nunc eget lorem dolor. Integer vitae justo eget magna fermentum.{' '}
+      </p>
+    </TabContent>
+  </Tabs>
+))


### PR DESCRIPTION
PR for issue #16. I've added these three components as described in the issue. Rather than mapping the children, I filtered the odd ones (TabHeading components) and then the even ones (TabContent components) and finally joined the two arrays together to reorder the components in accordance with PaperCSS.